### PR TITLE
feat: blank filling php for debt buyer and collecitons

### DIFF
--- a/pkg/lib/base_segment.go
+++ b/pkg/lib/base_segment.go
@@ -875,7 +875,7 @@ func (r *BaseSegment) ValidatePaymentHistoryProfile() error {
 			PaymentHistoryPast120, PaymentHistoryPast150, PaymentHistoryPast180, PaymentHistoryNoPayment,
 			PaymentHistoryNoPaymentMonth, PaymentHistoryZero, PaymentHistoryCollection,
 			PaymentHistoryForeclosureCompleted, PaymentHistoryVoluntarySurrender, PaymentHistoryRepossession,
-			PaymentHistoryChargeOff, PaymentHistoryTooNew:
+			PaymentHistoryChargeOff, PaymentHistoryTooNew, PaymentHistoryNoHistory:
 			continue
 		}
 		return utils.NewErrInvalidValueOfField("payment history profile", "base segment")
@@ -1329,7 +1329,7 @@ func (r *PackedBaseSegment) ValidatePaymentHistoryProfile() error {
 			PaymentHistoryPast120, PaymentHistoryPast150, PaymentHistoryPast180, PaymentHistoryNoPayment,
 			PaymentHistoryNoPaymentMonth, PaymentHistoryZero, PaymentHistoryCollection,
 			PaymentHistoryForeclosureCompleted, PaymentHistoryVoluntarySurrender, PaymentHistoryRepossession,
-			PaymentHistoryChargeOff:
+			PaymentHistoryChargeOff, PaymentHistoryNoHistory:
 			continue
 		}
 		return utils.NewErrInvalidValueOfField("payment history profile", "packed base segment")

--- a/pkg/lib/constants.go
+++ b/pkg/lib/constants.go
@@ -107,6 +107,8 @@ const (
 	PaymentHistoryChargeOff = 'L'
 	// consecutive payment activity, Too new to rate
 	PaymentHistoryTooNew = 'Z'
+	// consecutive payment activity, No payment history available prior to this time (collections and debt payer)
+	PaymentHistoryNoHistory = ' '
 	//  status code that properly identifies the current condition of the account, "DF"
 	AccountStatusDF = "DF"
 	//  status code that properly identifies the current condition of the account, "DA"


### PR DESCRIPTION
adding blank fill const validation for php which is allowed for debt buyers and collections