### PR TITLE
fix: update rexml version to address vuln

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -27,3 +27,4 @@ end
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
 
+gem "rexml", "3.3.9"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -243,7 +243,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rexml (3.2.6)
+    rexml (3.3.9)
     rouge (3.26.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)


### PR DESCRIPTION
Update rexml version to address vuln: https://app.vanta.com/vulnerabilities/findings-by-vulnerability?source=github&severity=CRITICAL&severity=HIGH&fixAvailable=Fixable